### PR TITLE
Fix heath bar issue

### DIFF
--- a/components/PlayerHealthBar.vue
+++ b/components/PlayerHealthBar.vue
@@ -1,10 +1,7 @@
 <template>
   <div
-    class="animate__animated relative flex items-center justify-center w-full"
-    :class="[
-      isCharging && 'animate__flash animate__infinite',
-      isSmall ? 'h-10' : 'h-12'
-    ]"
+    class="animate__animated relative flex h-12 w-full items-center justify-center"
+    :class="[isCharging && 'animate__flash animate__infinite']"
   >
     <span
       v-if="route.path !== '/game/player-name'"
@@ -37,11 +34,7 @@ const props = defineProps({
   isChargeHealth: {
     type: Boolean,
     default: false
-  },
-  isSmall: {
-    type: Boolean,
-    default: false
-  },
+  }
 })
 
 const isCharging = ref(false)

--- a/components/PlayerHealthBar.vue
+++ b/components/PlayerHealthBar.vue
@@ -42,10 +42,6 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
-  isFullWidth: {
-    type: Boolean,
-    default: false
-  }
 })
 
 const isCharging = ref(false)

--- a/components/PlayerHealthBar.vue
+++ b/components/PlayerHealthBar.vue
@@ -1,10 +1,9 @@
 <template>
   <div
-    class="animate__animated relative flex items-center justify-center"
+    class="animate__animated relative flex items-center justify-center w-full"
     :class="[
       isCharging && 'animate__flash animate__infinite',
-      isSmall ? 'h-10' : 'h-12',
-      isFullWidth ? 'w-full' : 'w-96'
+      isSmall ? 'h-10' : 'h-12'
     ]"
   >
     <span

--- a/components/TheNavigation.vue
+++ b/components/TheNavigation.vue
@@ -18,10 +18,7 @@
         v-if="isGameInProgress"
         class="hidden md:block"
       >
-        <PlayerHealthBar
-          :player-health="playerHealth"
-          is-small
-        />
+        <PlayerHealthBar :player-health="playerHealth" />
       </li>
       <li
         v-if="isGameInProgress"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,8 +17,6 @@
           v-if="isGameInProgress"
           class="z-50 md:hidden"
           :player-health="playerHealth"
-          is-small
-          is-full-width
         />
       </footer>
     </div>


### PR DESCRIPTION
I deleted the class binding because the value never changes and is always false. this leads to a width of w-96 (24rem). with a hardcoded width of w-full (100%) the loading bar aka health bar stays in the frame. 

Edit:  can you explain what the prop "isSmall" does?